### PR TITLE
Add PHPUnit tests and refactor for testability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^9.6"
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <file>wrapper.php</file>
+            <file>video.php</file>
+        </include>
+    </coverage>
+</phpunit>

--- a/tests/VideoTest.php
+++ b/tests/VideoTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class VideoTest extends TestCase
+{
+    private string $file;
+
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $_SESSION = [];
+        $this->file = __DIR__ . '/../small.mp4';
+    }
+
+    public function testServeVideoWithoutRange(): void
+    {
+        $crc = substr(sha1('small.mp4'), -8, -1);
+        $_SESSION['defaprotect' . $crc] = $this->file;
+
+        $headers = [];
+        $calledFile = null;
+        $result = defaprotect_serve_video(
+            $_SESSION,
+            [],
+            $crc,
+            function (string $h) use (&$headers) { $headers[] = $h; },
+            function (string $file) use (&$calledFile) { $calledFile = $file; }
+        );
+
+        $this->assertSame($this->file, $result['file']);
+        $this->assertSame($this->file, $calledFile);
+        $this->assertContains('Content-Type: video/mp4', $headers);
+        $this->assertContains('Accept-Ranges: bytes', $headers);
+        $this->assertContains('Content-Length: ' . filesize($this->file), $headers);
+    }
+
+    public function testServeVideoWithRange(): void
+    {
+        $crc = substr(sha1('small.mp4'), -8, -1);
+        $_SESSION['defaprotect' . $crc] = $this->file;
+
+        $headers = [];
+        $result = defaprotect_serve_video(
+            $_SESSION,
+            ['HTTP_RANGE' => 'bytes=0-1'],
+            $crc,
+            function (string $h) use (&$headers) { $headers[] = $h; },
+            function () { /* ignore */ }
+        );
+
+        $this->assertContains('HTTP/1.1 206 Partial Content', $headers);
+        $this->assertContains('Content-Range: bytes 0-1/' . filesize($this->file), $headers);
+        $this->assertContains('Content-Length: 2', $headers);
+    }
+
+    public function testServeVideoInvalidRange(): void
+    {
+        $crc = substr(sha1('small.mp4'), -8, -1);
+        $_SESSION['defaprotect' . $crc] = $this->file;
+
+        $headers = [];
+        $result = defaprotect_serve_video(
+            $_SESSION,
+            ['HTTP_RANGE' => 'bytes=10000-10001'],
+            $crc,
+            function (string $h) use (&$headers) { $headers[] = $h; },
+            function () { /* ignore */ }
+        );
+
+        $this->assertContains('HTTP/1.1 416 Requested Range Not Satisfiable', $headers);
+    }
+}

--- a/tests/WrapperTest.php
+++ b/tests/WrapperTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class WrapperTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $_SESSION = [];
+    }
+
+    public function testTransformsVideoSource(): void
+    {
+        ob_start();
+        include __DIR__ . '/../wrapper.php';
+        echo '<video src="small.mp4"></video>';
+        $output = ob_get_clean();
+
+        $crc = substr(sha1('small.mp4'), -8, -1);
+        $expected = '<video src="/video.php?crc=' . $crc . '"></video>';
+
+        $this->assertSame($expected, $output);
+        $this->assertSame('small.mp4', $_SESSION['defaprotect' . $crc]);
+    }
+
+    public function testIgnoresSafeTag(): void
+    {
+        ob_start();
+        include __DIR__ . '/../wrapper.php';
+        echo '<safe><video src="small.mp4"></video></safe>';
+        $output = ob_get_clean();
+
+        $this->assertSame('<safe><video src="small.mp4"></video></safe>', $output);
+        $this->assertEmpty($_SESSION);
+    }
+}

--- a/video.php
+++ b/video.php
@@ -2,82 +2,111 @@
 
 declare(strict_types=1);
 
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
+if (!function_exists('defaprotect_serve_video')) {
+    /**
+     * Process a video request and return streaming information.
+     *
+     * @return array{headers: array<int, string>, file: string, context: resource|null}
+     */
+    function defaprotect_serve_video(array &$session, array $server, string $crc, callable $headerFn, callable $readfileFn): array
+    {
+        ob_start();
+
+        $file = $session['defaprotect' . $crc] ?? '';
+
+        $headers = @get_headers($file, true);
+        if ($headers !== false && !empty($headers['Location'])) {
+            $file = $headers['Location'];
+        }
+
+        $size   = filesize($file);
+        $length = $size;
+        $start  = 0;
+        $end    = $size - 1;
+        $fp     = @fopen($file, 'rb');
+
+        $headersOut = [];
+        $headerFn('Content-Type: video/mp4');
+        $headersOut[] = 'Content-Type: video/mp4';
+        $headerFn('Accept-Ranges: bytes');
+        $headersOut[] = 'Accept-Ranges: bytes';
+
+        if (isset($server['HTTP_RANGE'])) {
+            $cStart = $start;
+            $cEnd   = $end;
+
+            [, $range] = explode('=', $server['HTTP_RANGE'], 2);
+            if (strpos($range, ',') !== false) {
+                $headerFn('HTTP/1.1 416 Requested Range Not Satisfiable');
+                $headerFn("Content-Range: bytes $start-$end/$size");
+                $headersOut[] = 'HTTP/1.1 416 Requested Range Not Satisfiable';
+                $headersOut[] = "Content-Range: bytes $start-$end/$size";
+                ob_end_clean();
+                return ['headers' => $headersOut, 'file' => $file, 'context' => null];
+            }
+
+            if ($range === '-') {
+                $cStart = $size - substr($range, 1);
+            } else {
+                $rangeParts = explode('-', $range);
+                $cStart     = (int) $rangeParts[0];
+                $cEnd       = isset($rangeParts[1]) && is_numeric($rangeParts[1])
+                    ? (int) $rangeParts[1]
+                    : $size;
+            }
+
+            $cEnd = ($cEnd > $end) ? $end : $cEnd;
+            if ($cStart > $cEnd || $cStart > $size - 1 || $cEnd >= $size) {
+                $headerFn('HTTP/1.1 416 Requested Range Not Satisfiable');
+                $headerFn("Content-Range: bytes $start-$end/$size");
+                $headersOut[] = 'HTTP/1.1 416 Requested Range Not Satisfiable';
+                $headersOut[] = "Content-Range: bytes $start-$end/$size";
+                ob_end_clean();
+                return ['headers' => $headersOut, 'file' => $file, 'context' => null];
+            }
+
+            $start  = $cStart;
+            $end    = $cEnd;
+            $length = $end - $start + 1;
+            if ($fp !== false) {
+                fseek($fp, $start);
+            }
+
+            $headerFn('HTTP/1.1 206 Partial Content');
+            $headersOut[] = 'HTTP/1.1 206 Partial Content';
+        }
+
+        $headerFn("Content-Range: bytes $start-$end/$size");
+        $headersOut[] = "Content-Range: bytes $start-$end/$size";
+        $headerFn("Content-Length: $length");
+        $headersOut[] = "Content-Length: $length";
+
+        $opts = [
+            'http' => [
+                'header' => sprintf(
+                    "Range: bytes=%d-%d\r\nContent-Type: video/mp4\r\nAccept-Ranges: bytes\r\nContent-Disposition: inline\r\nContent-Transfer-Encoding: binary\r\nConnection: close",
+                    $start,
+                    $end
+                ),
+                'method' => 'GET',
+            ],
+        ];
+        $context = stream_context_create($opts);
+
+        ob_end_clean();
+
+        $readfileFn($file, false, $context);
+
+        return ['headers' => $headersOut, 'file' => $file, 'context' => $context];
+    }
 }
 
-ob_start();
+if (php_sapi_name() !== 'cli') {
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
 
-$crc  = filter_input(INPUT_GET, 'crc', FILTER_SANITIZE_STRING);
-$file = $_SESSION['defaprotect' . $crc] ?? '';
-
-$headers = @get_headers($file, true);
-if ($headers !== false && !empty($headers['Location'])) {
-    $file = $headers['Location'];
+    $crc = filter_input(INPUT_GET, 'crc', FILTER_SANITIZE_STRING) ?? '';
+    defaprotect_serve_video($_SESSION, $_SERVER, $crc, 'header', 'readfile');
+    exit;
 }
-
-$size   = filesize($file);
-$length = $size;
-$start  = 0;
-$end    = $size - 1;
-$fp     = @fopen($file, 'rb');
-
-header('Content-Type: video/mp4');
-header('Accept-Ranges: bytes');
-
-if (isset($_SERVER['HTTP_RANGE'])) {
-    $cStart = $start;
-    $cEnd   = $end;
-
-    [, $range] = explode('=', $_SERVER['HTTP_RANGE'], 2);
-    if (strpos($range, ',') !== false) {
-        header('HTTP/1.1 416 Requested Range Not Satisfiable');
-        header("Content-Range: bytes $start-$end/$size");
-        exit;
-    }
-
-    if ($range === '-') {
-        $cStart = $size - substr($range, 1);
-    } else {
-        $rangeParts = explode('-', $range);
-        $cStart     = (int) $rangeParts[0];
-        $cEnd       = isset($rangeParts[1]) && is_numeric($rangeParts[1])
-            ? (int) $rangeParts[1]
-            : $size;
-    }
-
-    $cEnd = ($cEnd > $end) ? $end : $cEnd;
-    if ($cStart > $cEnd || $cStart > $size - 1 || $cEnd >= $size) {
-        header('HTTP/1.1 416 Requested Range Not Satisfiable');
-        header("Content-Range: bytes $start-$end/$size");
-        exit;
-    }
-
-    $start  = $cStart;
-    $end    = $cEnd;
-    $length = $end - $start + 1;
-    fseek($fp, $start);
-
-    header('HTTP/1.1 206 Partial Content');
-}
-
-header("Content-Range: bytes $start-$end/$size");
-header("Content-Length: $length");
-
-$opts = [
-    'http' => [
-        'header' => sprintf(
-            "Range: bytes=%d-%d\r\nContent-Type: video/mp4\r\nAccept-Ranges: bytes\r\nContent-Disposition: inline\r\nContent-Transfer-Encoding: binary\r\nConnection: close",
-            $start,
-            $end
-        ),
-        'method' => 'GET',
-    ],
-];
-$cong = stream_context_create($opts);
-
-ob_end_clean();
-
-readfile($file, false, $cong);
-
-exit;

--- a/wrapper.php
+++ b/wrapper.php
@@ -6,8 +6,13 @@ if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
 
-ob_start(
-    static function (string $output): string {
+if (!function_exists('defaprotect_transform_output')) {
+    /**
+     * Transform video, audio and source tags so that their sources point to the
+     * protected streaming endpoint.
+     */
+    function defaprotect_transform_output(string $output): string
+    {
         if (
             (strpos($output, '<video') > -1 ||
                 strpos($output, '<audio') > -1 ||
@@ -22,17 +27,17 @@ ob_start(
             };
 
             $output = preg_replace_callback(
-                '/(<video[^>]*src *= *[\"\']?)([^\"\']*)/i',
+                '/(<video[^>]*src *= *[\\"\\']?)([^\\"\\']*)/i',
                 $getUrl,
                 $output
             );
             $output = preg_replace_callback(
-                '/(<source[^>]*src *= *[\"\']?)([^\"\']*)/i',
+                '/(<source[^>]*src *= *[\\"\\']?)([^\\"\\']*)/i',
                 $getUrl,
                 $output
             );
             $output = preg_replace_callback(
-                '/(<audio[^>]*src *= *[\"\']?)([^\"\']*)/i',
+                '/(<audio[^>]*src *= *[\\"\\']?)([^\\"\\']*)/i',
                 $getUrl,
                 $output
             );
@@ -40,5 +45,6 @@ ob_start(
 
         return $output;
     }
-);
+}
 
+ob_start('defaprotect_transform_output');


### PR DESCRIPTION
## Summary
- refactor wrapper.php and video.php to expose testable functions
- add composer and phpunit configuration
- add PHPUnit tests for wrapper and video streaming logic

## Testing
- `phpunit --coverage-text` *(fails: phpunit not installed)*
- `composer install` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854b72193f0832ca4d6a6f89f7734c4